### PR TITLE
Use load() instead of play() for looping

### DIFF
--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -187,7 +187,7 @@
 				// if we have some loops to throw
 				if (loops_left)
 					// replay that bad boy
-					v.play();
+					v.load();
 				
 				// if not forever
 				if (loops_left !== true)


### PR DESCRIPTION
Looping (either done by loop attribute or the event handler from this source code) in Chrome only works if the content is served with "partial content request". 

If we replace the play() method by load(), it works. Tested on Chrome, FF and Safari.
