### PR TITLE
More aesthetic poster image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Browser Support
 ---------------
 
 <table>
+<tr><th>Browser</th><th>Video Support</th><th>Image Support</th></tr>
 <tr><td>Firefox 4+ (the best experience)</td><td>Yes (webm)</td><td>Yes</td></tr>
 <tr><td>Internet Explorer 9+</td><td>Yes (mp4)</td><td>Yes</td></tr>
 <tr><td>Firefox 3.5</td><td>Yes (ogv)</td><td>Yes</td></tr>

--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -144,7 +144,11 @@
 		var $video = $('<video/>');
 		$video.css('position','absolute')
 			.css('z-index',options.zIndex)
-			.attr('poster',options.poster)
+      .attr('poster', 'data:image/gif,AAAA')
+      .css('background-image', 'url(' + options.poster + ')')
+      .css('background-repeat', 'no-repeat')
+      .css('background-position', 'center')
+      .css('background-size', 'cover')
 			.css('top',0)
 			.css('left',0)
 			.css('min-width','100%')


### PR DESCRIPTION
When testing the poster attr (on Android) I noticed that the video element contains the entire image, leaving margins. This modification uses a transparent PNG (as a data URI) as the poster image, and sets the real poster image as the video element's background, allowing it to stretch to fill the entire element.

I've also updated the table in the readme to add headings.
