### PR TITLE
Changed video support check order

### DIFF
--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -208,15 +208,8 @@
 		
 		// if supports video
 		if ($.fn.videoBG.supportsVideo()) {
-
-		  	// supports webm
-		  	if ($.fn.videoBG.supportType('webm')){
-		  		
-		  		// play webm
-		  		$video.attr('src',options.webm);
-		  	}
 		  	// supports mp4
-		  	else if ($.fn.videoBG.supportType('mp4')) {	  	
+		  	if ($.fn.videoBG.supportType('mp4')) {	  	
 		  		
 		  		// play mp4
 		  		$video.attr('src',options.mp4);
@@ -224,6 +217,12 @@
 		  	//	$video.html('<source src="'.options.mp4.'" />');
 		  		
 		  	}
+		  	// supports webm
+		  	else if ($.fn.videoBG.supportType('webm')){
+                                 
+                                 // play webm
+                                 $video.attr('src',options.webm);
+                         }
 		  	// throw ogv at it then
 		  	else {
 		  		


### PR DESCRIPTION
Check mp4 first because Safari might report that it "probably" supports webm when it really doesn't.
