### PR TITLE
Clone container contents instead of container itself

### DIFF
--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -64,7 +64,7 @@
 		}
 		
 		// move the contents into the wrapper
-		wrap.html(container.clone(true));
+		wrap.html(container.children().clone(true));
 		
 		// get the video
 		var video = $.fn.videoBG.video(options);


### PR DESCRIPTION
When the line `wrap.html(container.html());` was changed to `wrap.html(container.clone(true));` it fixed the problem of JS events getting lost, but now instead of copying the container content, it makes a duplicate of the container itself. This duplication leads to problems with the default videoBG usage, as it creates another `<body>` element within the main `<body>` element, which in turn causes incompatibilities with other plugins and code that perform operations on `$(“body”)`.

This commit still uses the jQuery clone() method to maintain JS events, but instead of cloning the container, it clones the container’s children (i.e. its content) into the videoBG wrapper.
