### PR TITLE
Make all video types optional

### DIFF
--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -223,19 +223,19 @@
     if ($.fn.videoBG.supportsVideo()) {
 
       // supports webm
-      if ($.fn.videoBG.supportType('webm')){
+      if ($.fn.videoBG.supportType('webm') && options.webm){
 
         // play webm
         $video.attr('src',options.webm);
       }
       // supports mp4
-      else if ($.fn.videoBG.supportType('mp4')) {
+      else if ($.fn.videoBG.supportType('mp4') && options.mp4) {
 
         // play mp4
         $video.attr('src',options.mp4);
       }
       // throw ogv at it then
-      else {
+      else if (options.ogv) {
 
         // play ogv
         $video.attr('src',options.ogv);


### PR DESCRIPTION
It'd be nice if not all types were required. Conversion is easy enough, but for testing purposes and just in case all types are not wanted, it's a good option to have.