### PR TITLE
Updated to work with Safari 11 no autoplay feature on video's 

### DIFF
--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -163,6 +163,10 @@
     if (options.autoplay) {
       $video.attr('autoplay',options.autoplay);
     }
+   
+    if (options.muted) {
+      $video.attr('muted', options.muted);
+    }
 
     // if fullscreen
     if (options.fullscreen) {
@@ -332,6 +336,7 @@
     webm:'',
     poster:'',
     autoplay:true,
+    muted:false,
     loop:true,
     scale:false,
     position:"absolute",

--- a/jquery.videoBG.js
+++ b/jquery.videoBG.js
@@ -336,7 +336,7 @@
     webm:'',
     poster:'',
     autoplay:true,
-    muted:false,
+    muted:true,
     loop:true,
     scale:false,
     position:"absolute",


### PR DESCRIPTION
Added the html5 video muted tag and added the ability to set it to true or false as an option. It defaults to true automatically. 

Safari 11 introduced new features to no longer allow video's to autoplay on websites by default it doesn't autoplay anything with sound so by adding the muted tag it bypasses that flag and allows your BGVideo to play.